### PR TITLE
Use absolute link to https://hyper.sh/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Note:
 >
->This project is inspired by and based on [aci-connector-k8s](https://github.com/Azure/aci-connector-k8s). We chose to create a new repo, instead of sending a PR, simply because that this is merely a quick change. In the future, a new open framework is desired to support all container-first infrastructure service with driver plugins, including [ACI](https://azure.microsoft.com/en-us/services/container-instances/) and [Hyper.sh](hyper.sh). 
+>This project is inspired by and based on [aci-connector-k8s](https://github.com/Azure/aci-connector-k8s). We chose to create a new repo, instead of sending a PR, simply because that this is merely a quick change. In the future, a new open framework is desired to support all container-first infrastructure service with driver plugins, including [ACI](https://azure.microsoft.com/en-us/services/container-instances/) and [Hyper.sh](https://hyper.sh/). 
 
 The [Hyper.sh](https://hyper.sh/) Container Connector for Kubernetes allows Kubernetes clusters to deploy Hyper.sh Container.
 


### PR DESCRIPTION
Otherwise Github resolves this to https://github.com/hyperhq/hyper.sh-connector-k8s/blob/master/hyper.sh